### PR TITLE
Alternate vCPU suspension method

### DIFF
--- a/lib/libvmmapi/vmmapi.c
+++ b/lib/libvmmapi/vmmapi.c
@@ -47,7 +47,6 @@ __FBSDID("$FreeBSD$");
 #include <assert.h>
 #include <string.h>
 #include <fcntl.h>
-#include <pthread.h>
 #include <unistd.h>
 
 #include <libutil.h>
@@ -72,14 +71,6 @@ __FBSDID("$FreeBSD$");
 #define	PROT_RW		(PROT_READ | PROT_WRITE)
 #define	PROT_ALL	(PROT_READ | PROT_WRITE | PROT_EXEC)
 
-struct vcpu_lock {
-	pthread_mutex_t	vl_mtx;
-	int		vl_running_cnt;
-	pthread_cond_t	vl_run_complete_cond;
-	int		vl_paused;
-	pthread_cond_t	vl_paused_cond;
-};
-
 struct vmctx {
 	int	fd;
 	uint32_t lowmem_limit;
@@ -88,8 +79,6 @@ struct vmctx {
 	size_t	highmem;
 	char	*baseaddr;
 	char	*name;
-
-	struct vcpu_lock lock;
 };
 
 #define	CREATE(x)  sysctlbyname("hw.vmm.create", NULL, NULL, (x), strlen((x)))
@@ -124,7 +113,6 @@ struct vmctx *
 vm_open(const char *name)
 {
 	struct vmctx *vm;
-	struct vcpu_lock *lock;
 
 	vm = malloc(sizeof(struct vmctx) + strlen(name) + 1);
 	assert(vm != NULL);
@@ -137,14 +125,6 @@ vm_open(const char *name)
 
 	if ((vm->fd = vm_device_open(vm->name)) < 0)
 		goto err;
-
-	lock = &vm->lock;
-
-	pthread_mutex_init(&lock->vl_mtx, NULL);
-	lock->vl_running_cnt = 0;
-	pthread_cond_init(&lock->vl_run_complete_cond, NULL);
-	lock->vl_paused = 0;
-	pthread_cond_init(&lock->vl_paused_cond, NULL);
 
 	return (vm);
 err:
@@ -686,29 +666,12 @@ vm_run(struct vmctx *ctx, int vcpu, struct vm_exit *vmexit)
 {
 	int error;
 	struct vm_run vmrun;
-	struct vcpu_lock *lock;
-
-	lock = &ctx->lock;
-
-	pthread_mutex_lock(&lock->vl_mtx);
-	while (lock->vl_paused)
-		pthread_cond_wait(&lock->vl_paused_cond, &lock->vl_mtx);
-
-	lock->vl_running_cnt++;
-	pthread_mutex_unlock(&lock->vl_mtx);
 
 	bzero(&vmrun, sizeof(vmrun));
 	vmrun.cpuid = vcpu;
 
 	error = ioctl(ctx->fd, VM_RUN, &vmrun);
 	bcopy(&vmrun.vm_exit, vmexit, sizeof(struct vm_exit));
-
-	pthread_mutex_lock(&lock->vl_mtx);
-	lock->vl_running_cnt--;
-	if (lock->vl_running_cnt == 0)
-		pthread_cond_broadcast(&lock->vl_run_complete_cond);
-	pthread_mutex_unlock(&lock->vl_mtx);
-
 	return (error);
 }
 
@@ -1580,39 +1543,6 @@ vm_restart_instruction(void *arg, int vcpu)
 	struct vmctx *ctx = arg;
 
 	return (ioctl(ctx->fd, VM_RESTART_INSTRUCTION, &vcpu));
-}
-
-void
-vm_vcpu_pause(struct vmctx *ctx)
-{
-	struct vcpu_lock *lock;
-	struct vm_activate_cpu ac;
-
-	lock = &ctx->lock;
-
-	pthread_mutex_lock(&lock->vl_mtx);
-	lock->vl_paused = 1;
-
-	bzero(&ac, sizeof(struct vm_activate_cpu));
-	ac.vcpuid = -1;
-	ac.no_debug = 1;
-	ioctl(ctx->fd, VM_SUSPEND_CPU, &ac);
-	while (lock->vl_running_cnt != 0)
-		pthread_cond_wait(&lock->vl_run_complete_cond, &lock->vl_mtx);
-	pthread_mutex_unlock(&lock->vl_mtx);
-}
-
-void
-vm_vcpu_resume(struct vmctx *ctx)
-{
-	struct vcpu_lock *lock;
-
-	lock = &ctx->lock;
-
-	pthread_mutex_lock(&lock->vl_mtx);
-	lock->vl_paused = 0;
-	pthread_cond_broadcast(&lock->vl_paused_cond);
-	pthread_mutex_unlock(&lock->vl_mtx);
 }
 
 int

--- a/lib/libvmmapi/vmmapi.h
+++ b/lib/libvmmapi/vmmapi.h
@@ -235,8 +235,6 @@ int	vm_set_topology(struct vmctx *ctx, uint16_t sockets, uint16_t cores,
 	    uint16_t threads, uint16_t maxcpus);
 int	vm_get_topology(struct vmctx *ctx, uint16_t *sockets, uint16_t *cores,
 	    uint16_t *threads, uint16_t *maxcpus);
-void	vm_vcpu_pause(struct vmctx *ctx);
-void	vm_vcpu_resume(struct vmctx *ctx);
 
 /*
  * FreeBSD specific APIs

--- a/sys/amd64/include/vmm.h
+++ b/sys/amd64/include/vmm.h
@@ -253,7 +253,7 @@ int vm_get_x2apic_state(struct vm *vm, int vcpu, enum x2apic_state *state);
 int vm_set_x2apic_state(struct vm *vm, int vcpu, enum x2apic_state state);
 int vm_apicid2vcpuid(struct vm *vm, int apicid);
 int vm_activate_cpu(struct vm *vm, int vcpu);
-int vm_suspend_cpu(struct vm *vm, int vcpu, int no_debug);
+int vm_suspend_cpu(struct vm *vm, int vcpu);
 int vm_resume_cpu(struct vm *vm, int vcpu);
 struct vm_exit *vm_exitinfo(struct vm *vm, int vcpuid);
 void vm_exit_suspended(struct vm *vm, int vcpuid, uint64_t rip);

--- a/sys/amd64/include/vmm_dev.h
+++ b/sys/amd64/include/vmm_dev.h
@@ -202,7 +202,6 @@ struct vm_gla2gpa {
 
 struct vm_activate_cpu {
 	int		vcpuid;
-	int		no_debug;
 };
 
 struct vm_cpuset {

--- a/sys/amd64/vmm/vmm.c
+++ b/sys/amd64/vmm/vmm.c
@@ -2343,7 +2343,7 @@ vm_activate_cpu(struct vm *vm, int vcpuid)
 }
 
 int
-vm_suspend_cpu(struct vm *vm, int vcpuid, int no_debug)
+vm_suspend_cpu(struct vm *vm, int vcpuid)
 {
 	int i;
 
@@ -2351,8 +2351,7 @@ vm_suspend_cpu(struct vm *vm, int vcpuid, int no_debug)
 		return (EINVAL);
 
 	if (vcpuid == -1) {
-		if (no_debug == 0)
-		    vm->debug_cpus = vm->active_cpus;
+		vm->debug_cpus = vm->active_cpus;
 		for (i = 0; i < VM_MAXCPU; i++) {
 			if (CPU_ISSET(i, &vm->active_cpus))
 				vcpu_notify_event(vm, i, false);
@@ -2361,8 +2360,7 @@ vm_suspend_cpu(struct vm *vm, int vcpuid, int no_debug)
 		if (!CPU_ISSET(vcpuid, &vm->active_cpus))
 			return (EINVAL);
 
-		if (no_debug == 0)
-		    CPU_SET_ATOMIC(vcpuid, &vm->debug_cpus);
+		CPU_SET_ATOMIC(vcpuid, &vm->debug_cpus);
 		vcpu_notify_event(vm, vcpuid, false);
 	}
 	return (0);

--- a/sys/amd64/vmm/vmm_dev.c
+++ b/sys/amd64/vmm/vmm_dev.c
@@ -726,7 +726,7 @@ vmmdev_ioctl(struct cdev *cdev, u_long cmd, caddr_t data, int fflag,
 		break;
 	case VM_SUSPEND_CPU:
 		vac = (struct vm_activate_cpu *)data;
-		error = vm_suspend_cpu(sc->vm, vac->vcpuid, vac->no_debug);
+		error = vm_suspend_cpu(sc->vm, vac->vcpuid);
 		break;
 	case VM_RESUME_CPU:
 		vac = (struct vm_activate_cpu *)data;

--- a/usr.sbin/bhyve/bhyverun.c
+++ b/usr.sbin/bhyve/bhyverun.c
@@ -436,6 +436,7 @@ fbsdrun_start_thread(void *param)
 	snprintf(tname, sizeof(tname), "vcpu %d", vcpu);
 	pthread_set_name_np(mtp->mt_thr, tname);
 
+	checkpoint_cpu_add(vcpu);
 	gdb_cpu_add(vcpu);
 
 	vm_loop(mtp->mt_ctx, vcpu, vmexit[vcpu].rip);
@@ -790,7 +791,9 @@ static int
 vmexit_debug(struct vmctx *ctx, struct vm_exit *vmexit, int *pvcpu)
 {
 
+	checkpoint_cpu_suspend(*pvcpu);
 	gdb_cpu_suspend(*pvcpu);
+	checkpoint_cpu_resume(*pvcpu);
 	return (VMEXIT_CONTINUE);
 }
 

--- a/usr.sbin/bhyve/bhyverun.c
+++ b/usr.sbin/bhyve/bhyverun.c
@@ -711,7 +711,9 @@ vmexit_mtrap(struct vmctx *ctx, struct vm_exit *vmexit, int *pvcpu)
 
 	stats.vmexit_mtrap++;
 
+	checkpoint_cpu_suspend(*pvcpu);
 	gdb_cpu_mtrap(*pvcpu);
+	checkpoint_cpu_resume(*pvcpu);
 
 	return (VMEXIT_CONTINUE);
 }

--- a/usr.sbin/bhyve/snapshot.c
+++ b/usr.sbin/bhyve/snapshot.c
@@ -1043,6 +1043,7 @@ vm_vcpu_resume(struct vmctx *ctx)
 	pthread_mutex_lock(&vcpu_lock);
 	checkpoint_active = false;
 	pthread_mutex_unlock(&vcpu_lock);
+	vm_resume_cpu(ctx, -1);
 	pthread_cond_broadcast(&vcpus_can_run);
 }
 

--- a/usr.sbin/bhyve/snapshot.c
+++ b/usr.sbin/bhyve/snapshot.c
@@ -113,6 +113,11 @@ const struct vm_snapshot_kern_info snapshot_kern_structs[] = {
 	{ "vrtc",	STRUCT_VRTC	},
 };
 
+static cpuset_t vcpus_active, vcpus_suspended;
+static pthread_mutex_t vcpu_lock;
+static pthread_cond_t vcpus_idle, vcpus_can_run;
+static bool checkpoint_active;
+
 /*
  * TODO: Harden this function and all of its callers since 'base_str' is a user
  * provided string.
@@ -971,6 +976,76 @@ vm_mem_write_to_file(int fd, const void *src, size_t dst_offset, size_t len)
 	return (0);
 }
 
+void
+checkpoint_cpu_add(int vcpu)
+{
+
+	pthread_mutex_lock(&vcpu_lock);
+	CPU_SET(vcpu, &vcpus_active);
+
+	if (checkpoint_active) {
+		CPU_SET(vcpu, &vcpus_suspended);
+		while (checkpoint_active)
+			pthread_cond_wait(&vcpus_can_run, &vcpu_lock);
+		CPU_CLR(vcpu, &vcpus_suspended);
+	}
+	pthread_mutex_unlock(&vcpu_lock);
+}
+
+/*
+ * When a vCPU is suspended for any reason, it calls
+ * checkpoint_cpu_suspend().  This records that the vCPU is idle.
+ * Before returning from suspension, checkpoint_cpu_resume() is
+ * called.  In suspend we note that the vCPU is idle.  In resume we
+ * pause the vCPU thread until the checkpoint is complete.  The reason
+ * for the two-step process is that vCPUs might already be stopped in
+ * the debug server when a checkpoint is requested.  This approach
+ * allows us to account for and handle those vCPUs.
+ */
+void
+checkpoint_cpu_suspend(int vcpu)
+{
+
+	pthread_mutex_lock(&vcpu_lock);
+	CPU_SET(vcpu, &vcpus_suspended);
+	if (checkpoint_active && CPU_CMP(&vcpus_active, &vcpus_suspended) == 0)
+		pthread_cond_signal(&vcpus_idle);
+	pthread_mutex_unlock(&vcpu_lock);
+}
+
+void
+checkpoint_cpu_resume(int vcpu)
+{
+
+	pthread_mutex_lock(&vcpu_lock);
+	while (checkpoint_active)
+		pthread_cond_wait(&vcpus_can_run, &vcpu_lock);
+	CPU_CLR(vcpu, &vcpus_suspended);
+	pthread_mutex_unlock(&vcpu_lock);
+}
+
+static void
+vm_vcpu_pause(struct vmctx *ctx)
+{
+
+	pthread_mutex_lock(&vcpu_lock);
+	checkpoint_active = true;
+	vm_suspend_cpu(ctx, -1);
+	while (CPU_CMP(&vcpus_active, &vcpus_suspended) != 0)
+		pthread_cond_wait(&vcpus_idle, &vcpu_lock);
+	pthread_mutex_unlock(&vcpu_lock);
+}
+
+static void
+vm_vcpu_resume(struct vmctx *ctx)
+{
+
+	pthread_mutex_lock(&vcpu_lock);
+	checkpoint_active = false;
+	pthread_mutex_unlock(&vcpu_lock);
+	pthread_cond_broadcast(&vcpus_can_run);
+}
+
 static int
 vm_checkpoint(struct vmctx *ctx, char *checkpoint_file, bool stop_vm)
 {
@@ -1213,6 +1288,15 @@ init_checkpoint_thread(struct vmctx *ctx)
 	pthread_t checkpoint_pthread;
 	char vmname_buf[MAX_VMNAME];
 	int ret, err = 0;
+
+	err = pthread_mutex_init(&vcpu_lock, NULL);
+	if (err != 0)
+		errc(1, err, "checkpoint mutex init");
+	err = pthread_cond_init(&vcpus_idle, NULL);
+	if (err == 0)
+		err = pthread_cond_init(&vcpus_can_run, NULL);
+	if (err != 0)
+		errc(1, err, "checkpoint cv init");
 
 	socket_fd = socket(PF_UNIX, SOCK_STREAM, 0);
 	if (socket_fd < 0) {

--- a/usr.sbin/bhyve/snapshot.h
+++ b/usr.sbin/bhyve/snapshot.h
@@ -50,6 +50,9 @@ int lookup_memflags(struct restore_state *rstate);
 size_t lookup_memsize(struct restore_state *rstate);
 int lookup_guest_ncpus(struct restore_state *rstate);
 
+void checkpoint_cpu_add(int vcpu);
+void checkpoint_cpu_resume(int vcpu);
+void checkpoint_cpu_suspend(int vcpu);
 
 int restore_vm_mem(struct vmctx *ctx, struct restore_state *rstate);
 int vm_restore_kern_structs(struct vmctx *ctx, struct restore_state *rstate);


### PR DESCRIPTION
This compiles, but I haven't run-time tested it. :(  This is what I tried to describe on the phone earlier today about using the debug vmexit as the hook for synchronizing with the checkpoint thread.  In this case I went ahead and left the thread as-is rather than being driven from the event of the last vCPU suspending.  It was a smaller patch and also avoids silliness with the case where all the vCPUs are already idle, etc.